### PR TITLE
test-speaker.sh: shellcheck quoting and exit code

### DIFF
--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -15,9 +15,11 @@
 ##       hear "front left" from the front left speaker.
 ##
 
-source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
+# shellcheck source=case-lib/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
+
+OPT_NAME['t']='tplg'     OPT_DESC['t']="tplg file, default value is env TPLG: $TPLG"
 OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='option of speaker-test'
@@ -33,26 +35,23 @@ logger_disabled || func_lib_start_log_collect
 func_pipeline_export "$tplg" "type:playback"
 tcnt=${OPT_VAL['l']}
 setup_kernel_check_point
-for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
+for idx in $(seq 0 $((PIPELINE_COUNT - 1)))
 do
-    channel=$(func_pipeline_parse_value $idx channel)
-    rate=$(func_pipeline_parse_value $idx rate)
-    fmt=$(func_pipeline_parse_value $idx fmt)
-    dev=$(func_pipeline_parse_value $idx dev)
-    snd=$(func_pipeline_parse_value $idx snd)
+    channel=$(func_pipeline_parse_value "$idx" channel)
+    rate=$(func_pipeline_parse_value "$idx" rate)
+    fmt=$(func_pipeline_parse_value "$idx" fmt)
+    dev=$(func_pipeline_parse_value "$idx" dev)
+    snd=$(func_pipeline_parse_value "$idx" snd)
 
     dlogc "speaker-test -D $dev -r $rate -c $channel -f $fmt -l $tcnt -t wav -P 8"
-    speaker-test -D $dev -r $rate -c $channel -f $fmt -l $tcnt -t wav -P 8 2>&1 |tee $LOG_ROOT/result_$idx.txt
-    resultRet=$?
+    speaker-test -D "$dev" -r "$rate" -c "$channel" -f "$fmt" -l "$tcnt" -t wav -P 8 2>&1 |tee "$LOG_ROOT"/result_"$idx".txt
+    resultRet=${PIPESTATUS[0]} 
 
-    if [[ $resultRet -eq 0 ]]; then
-        grep -nr -E "error|failed" $LOG_ROOT/result_$idx.txt
-        if [[ $? -eq 0 ]]; then
-            func_lib_lsof_error_dump $snd
+    if [[ $resultRet -ne 0  ]] ||
+        grep -nr -E "error|failed" "$LOG_ROOT"/result_"$idx".txt; then
+            func_lib_lsof_error_dump "$snd"
             die "speaker test failed"
-        fi
     fi
 done
 
 sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
-exit $?


### PR DESCRIPTION
Fixed a variety of quoting issues and a sticky pair of error condition handling.  The original code might have been bugged, but now works as one would expect and has been tested.

Signed off by Greg Galloway greg.galloway@intel.com